### PR TITLE
docs: add Docker env example

### DIFF
--- a/deploy/docker/.env.example
+++ b/deploy/docker/.env.example
@@ -1,0 +1,108 @@
+# DataBuff Docker Compose environment example
+#
+# Copy this file to .env before customizing the Docker deployment:
+#   cp .env.example .env
+#
+# The main ./start.sh script loads deploy/docker/env.sh when it is present in an
+# offline release package. Variables below mirror the Docker Compose files and
+# start scripts so contributors can see the available overrides without editing
+# docker-compose.yml. Values here are examples/defaults only; no real secrets are
+# required for the local Docker Compose stack.
+
+# -----------------------------------------------------------------------------
+# Release image selection
+# -----------------------------------------------------------------------------
+
+# Optional namespace used by deploy/env.sh to build the application image names.
+# If env.sh is present, APM_INGEST_IMAGE/APM_WEB_IMAGE/APM_DEMO_IMAGE default to
+# ${RUNTIME_IMAGE_NAMESPACE}/<service>:${APM_VERSION}.
+RUNTIME_IMAGE_NAMESPACE=databuffhub
+
+# Application version used by deploy/env.sh when deriving application image tags.
+# Release packages may also provide a VERSION file that overrides this value.
+APM_VERSION=0.1.3
+
+# Application images consumed by deploy/docker/docker-compose.yml.
+# Required when env.sh is not sourced before running docker compose directly.
+APM_INGEST_IMAGE=databuffhub/ai-apm-ingest:0.1.3
+APM_WEB_IMAGE=databuffhub/ai-apm-web:0.1.3
+
+# Demo seeder image consumed by deploy/docker/demo/docker-compose.yml.
+APM_DEMO_IMAGE=databuffhub/ai-apm-demo:0.1.3
+
+# Optional Docker Compose project name override for the main deployment.
+COMPOSE_PROJECT_NAME=databuff-ai-apm
+
+# -----------------------------------------------------------------------------
+# Offline package/image loading
+# -----------------------------------------------------------------------------
+
+# Base URL/path used by release scripts to locate versioned application packages.
+APM_PKG_BASE=http://192.168.50.140/databuff
+
+# Public-facing package base shown in user messages and generated summaries.
+APM_PUBLIC_PKG_BASE=http://192.168.50.140/databuff
+
+# Derived image package locations. Override only if your mirror layout differs.
+APM_IMAGES_PKG_BASE=http://192.168.50.140/databuff/0.1.3/images
+APM_INFRA_IMAGES_PKG_BASE=http://192.168.50.140/databuff/infra/images
+
+# Set to 1 to skip pulling/loading images in start scripts when images already
+# exist locally.
+SKIP_PULL_IMAGES=0
+
+# -----------------------------------------------------------------------------
+# Runtime/startup behavior
+# -----------------------------------------------------------------------------
+
+# Maximum seconds ./start.sh waits for ingest/web readiness checks.
+APM_READY_TIMEOUT=300
+
+# Set to 1 to skip readiness checks after starting containers.
+START_SKIP_READY=0
+
+# Set to 1 to suppress the final ready summary printed by ./start.sh.
+START_SKIP_SUMMARY=0
+
+# -----------------------------------------------------------------------------
+# Demo seeder overrides (deploy/docker/demo)
+# -----------------------------------------------------------------------------
+
+# Host/port used by demo/start.sh to derive OTLP and SkyWalking endpoints.
+# Leave INGEST_HOST unset to auto-detect the local host IP.
+# INGEST_HOST=192.168.1.10
+INGEST_PORT=4318
+
+# OTLP endpoint used by the demo container. If unset, demo/start.sh derives it
+# from INGEST_HOST and INGEST_PORT.
+OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4318
+
+# Demo protocol: otlp or skywalking.
+SEED_PROTOCOL=otlp
+
+# SkyWalking gRPC target used when SEED_PROTOCOL=skywalking.
+SKYWALKING_GRPC_TARGET=127.0.0.1:31800
+
+# Interval, in seconds, between demo telemetry batches.
+SEED_INTERVAL_SECONDS=30
+
+# JVM metrics interval used by the local development compose demo service.
+JVM_METRIC_INTERVAL_SECONDS=60
+
+# -----------------------------------------------------------------------------
+# Infrastructure image overrides (mainly local/dev compose)
+# -----------------------------------------------------------------------------
+
+# Java runtime image used by deploy/local/docker-compose.yml.
+OPENJDK_IMAGE=openjdk:17.0.2-jdk
+
+# Optional registry prefix for pulling the OpenJDK image before tagging it as
+# OPENJDK_IMAGE. Leave empty to pull/use the short image name directly.
+OPENJDK_REGISTRY=
+
+# Doris images used by deploy/local/docker-compose.yml.
+DORIS_FE_IMAGE=apache/doris:fe-4.1.1
+DORIS_BE_IMAGE=apache/doris:be-4.1.1
+
+# Zookeeper image used by legacy/package scripts when required.
+ZOOKEEPER_IMAGE=bitnamilegacy/zookeeper:3.9


### PR DESCRIPTION
## Summary
- Adds `deploy/docker/.env.example` documenting Docker Compose/start-script overrides for the Docker deployment and demo seeder.
- Includes safe example defaults for image names, package locations, startup toggles, demo telemetry settings, and local infrastructure image overrides.
- Leaves the existing `.env` and Compose files unchanged.

Fixes #12

## Validation
- `git diff --check origin/master..HEAD`
- `docker compose --env-file deploy/docker/.env.example -f deploy/docker/docker-compose.yml config >/tmp/databuff-compose-config.yml`
- Verified the example does not include `APM_PKG_UPLOAD_PASS` or other real upload credentials.

I did not run the full Docker stack locally because this is a documentation-only env example and starting the full Doris/APM stack is outside the scope of this change.
