### PR TITLE
docs: add Docker env example

### DIFF
--- a/deploy/docker/.env.example
+++ b/deploy/docker/.env.example
@@ -1,0 +1,96 @@
+# DataBuff Docker Compose environment example.
+# Copy this file to .env or export the variables in your shell before running
+# deploy/docker/start.sh. Do not put real production secrets in this file.
+
+# Optional. Namespace used to build the application image names below.
+# Default: databuffhub
+RUNTIME_IMAGE_NAMESPACE=databuffhub
+
+# Optional. Application version used for the ingest, web, and demo images.
+# deploy/docker/start.sh also reads VERSION when present.
+# Default in deploy/env.sh: 0.1.3
+APM_VERSION=0.1.3
+
+# Optional. Runtime application images used by docker-compose.yml.
+# Defaults are derived from RUNTIME_IMAGE_NAMESPACE and APM_VERSION:
+#   ${RUNTIME_IMAGE_NAMESPACE}/ai-apm-ingest:${APM_VERSION}
+#   ${RUNTIME_IMAGE_NAMESPACE}/ai-apm-web:${APM_VERSION}
+#   ${RUNTIME_IMAGE_NAMESPACE}/ai-apm-demo:${APM_VERSION}
+APM_INGEST_IMAGE=databuffhub/ai-apm-ingest:0.1.3
+APM_WEB_IMAGE=databuffhub/ai-apm-web:0.1.3
+APM_DEMO_IMAGE=databuffhub/ai-apm-demo:0.1.3
+
+# Optional. Infrastructure images used by the Docker deployment.
+# Defaults:
+#   DORIS_FE_IMAGE=apache/doris:fe-4.1.1
+#   DORIS_BE_IMAGE=apache/doris:be-4.1.1
+#   ZOOKEEPER_IMAGE=bitnamilegacy/zookeeper:3.9
+#   OPENJDK_IMAGE=openjdk:17.0.2-jdk
+DORIS_FE_IMAGE=apache/doris:fe-4.1.1
+DORIS_BE_IMAGE=apache/doris:be-4.1.1
+ZOOKEEPER_IMAGE=bitnamilegacy/zookeeper:3.9
+OPENJDK_IMAGE=openjdk:17.0.2-jdk
+
+# Optional. Registry prefix for pulling OPENJDK_IMAGE during local builds.
+# Leave empty to pull the short image name directly.
+# Example: OPENJDK_REGISTRY=registry.example.com/databuff
+OPENJDK_REGISTRY=
+
+# Optional. Demo telemetry settings used by the local/demo compose files.
+# Defaults:
+#   OTEL_EXPORTER_OTLP_ENDPOINT=http://ai-apm-ingest:4318
+#   SEED_PROTOCOL=otlp
+#   SKYWALKING_GRPC_TARGET=ai-apm-ingest:31800
+#   SEED_INTERVAL_SECONDS=30
+#   JVM_METRIC_INTERVAL_SECONDS=60
+OTEL_EXPORTER_OTLP_ENDPOINT=http://ai-apm-ingest:4318
+SEED_PROTOCOL=otlp
+SKYWALKING_GRPC_TARGET=ai-apm-ingest:31800
+SEED_INTERVAL_SECONDS=30
+JVM_METRIC_INTERVAL_SECONDS=60
+
+# Optional. Compose project name. This controls the Docker Compose project
+# namespace for generated resources.
+# Default: databuff-ai-apm
+COMPOSE_PROJECT_NAME=databuff-ai-apm
+
+# Optional. Base URL for deployment packages and image tarballs.
+# Default in deploy/env.sh: http://192.168.50.140/databuff
+APM_PKG_BASE=http://192.168.50.140/databuff
+
+# Optional. Public package base shown in install summaries.
+# Default: same internal package base used by APM_PKG_BASE.
+APM_PUBLIC_PKG_BASE=http://192.168.50.140/databuff
+
+# Optional. Override where versioned application image packages are downloaded.
+# Default: ${APM_PKG_BASE}/${APM_VERSION}/images
+# APM_IMAGES_PKG_BASE=
+
+# Optional. Override where infrastructure image packages are downloaded.
+# Default: ${APM_PKG_BASE}/infra/images
+# APM_INFRA_IMAGES_PKG_BASE=
+
+# Optional. Build/publish target used by release packaging scripts.
+# These are only needed when uploading generated packages.
+# Defaults in deploy/env.sh are placeholders for the project build host.
+# APM_PKG_UPLOAD_HOST=192.168.50.140
+# APM_PKG_UPLOAD_USER=root
+# APM_PKG_UPLOAD_PASS=
+# APM_PKG_REMOTE_DIR=/opt/databuff-site/databuff
+
+# Optional. Skip pulling/loading images before start.sh runs.
+# Set to 1 when the required images already exist locally.
+# Default: 0
+SKIP_PULL_IMAGES=0
+
+# Optional. Wait timeout, in seconds, for ingest and web readiness checks.
+# Default: 300
+APM_READY_TIMEOUT=300
+
+# Optional. Skip readiness checks after containers are started.
+# Default: 0
+START_SKIP_READY=0
+
+# Optional. Skip printing the ready summary after startup.
+# Default: 0
+START_SKIP_SUMMARY=0


### PR DESCRIPTION
## Summary
- add `deploy/docker/.env.example` for Docker Compose setup
- document app image, infrastructure image, package URL, compose, readiness, and demo telemetry variables
- keep existing `.env` and compose files unchanged

Fixes #12

## Testing
- `git diff --check`
- verified all variables interpolated by `deploy/docker/docker-compose.yml` and `deploy/local/docker-compose.yml` are documented in `.env.example`
- `docker compose --env-file deploy/docker/.env.example -f deploy/docker/docker-compose.yml config`
