### PR TITLE
fix(web): translate delete confirmations

### DIFF
--- a/ai-apm-frontend/src/views/configManage/alarm/rule/table-list.vue
+++ b/ai-apm-frontend/src/views/configManage/alarm/rule/table-list.vue
@@ -215,7 +215,7 @@ export default class TableList extends Vue {
     if (row.loading) {
       return;
     }
-    this.$confirm(`<p>{{ $t('modules.views.sysManage.org.s_bafb9cb6') }}</p>`, i18n.t('common.hint') as string, { type: 'warning', dangerouslyUseHTMLString: true })
+    this.$confirm(i18n.t('modules.views.sysManage.org.s_bafb9cb6') as string, i18n.t('common.hint') as string, { type: 'warning' })
       .then(async () => {
         this.$set(row, 'loading', true);
         const fetchUrl = this.isSystemRule ? 'batchDelSystemMonitor' : 'batchDelMonitor'

--- a/ai-apm-frontend/src/views/configManage/alarm/rulePreset/index.vue
+++ b/ai-apm-frontend/src/views/configManage/alarm/rulePreset/index.vue
@@ -138,7 +138,7 @@ export default class TemplateList extends Vue {
 
   // 删除规则
   private deleteHandle(row: any) {
-    this.$confirm(`<p>{{ $t('modules.views.sysManage.org.s_bafb9cb6') }}</p>`, i18n.t('common.hint') as string, { type: 'warning', dangerouslyUseHTMLString: true })
+    this.$confirm(i18n.t('modules.views.sysManage.org.s_bafb9cb6') as string, i18n.t('common.hint') as string, { type: 'warning' })
       .then(async () => {
         row.switchLoading = true
         const params = row.monitorIds.map((id: number) => ({ id }))

--- a/ai-apm-frontend/src/views/configManage/entity/process/table-list.vue
+++ b/ai-apm-frontend/src/views/configManage/entity/process/table-list.vue
@@ -110,7 +110,7 @@ export default class TableList extends Vue {
     if (row.loading) {
       return;
     }
-    this.$confirm(`<p>{{ $t('modules.views.sysManage.org.s_bafb9cb6') }}</p>`, i18n.t('common.hint') as string, { type: 'warning', dangerouslyUseHTMLString: true })
+    this.$confirm(i18n.t('modules.views.sysManage.org.s_bafb9cb6') as string, i18n.t('common.hint') as string, { type: 'warning' })
       .then(async () => {
         const fetchUrl = this.isRecognition ? 'deleteIdentifyRule' : 'deleteCollectRule'
         this.$set(row, 'loading', true);

--- a/ai-apm-frontend/src/views/sysManage/group/table-list.vue
+++ b/ai-apm-frontend/src/views/sysManage/group/table-list.vue
@@ -155,7 +155,7 @@ export default class GroupTableList extends Vue {
   }
 
   private async batchDeleteHandle () {
-    this.$confirm(`<p>{{ $t('modules.views.sysManage.org.s_bafb9cb6') }}</p>`, i18n.t('common.hint') as string, { type: 'warning', dangerouslyUseHTMLString: true })
+    this.$confirm(i18n.t('modules.views.sysManage.org.s_bafb9cb6') as string, i18n.t('common.hint') as string, { type: 'warning' })
       .then(async () => {
         const ids = this.selection.map((i) => i.id)
         if (ids.length) {

--- a/ai-apm-frontend/src/views/sysManage/health/config.vue
+++ b/ai-apm-frontend/src/views/sysManage/health/config.vue
@@ -214,7 +214,7 @@ export default class HealthComp extends Vue {
     this.ruleDetail = row;
   }
   private deleteRule(row: any) {
-    this.$confirm(`<p>{{ $t('modules.views.sysManage.org.s_bafb9cb6') }}</p>`, i18n.t('common.hint') as string, { type: 'warning', dangerouslyUseHTMLString: true })
+    this.$confirm(i18n.t('modules.views.sysManage.org.s_bafb9cb6') as string, i18n.t('common.hint') as string, { type: 'warning' })
       .then(async () => {
         this.tableLoading = true
         const { result, error } = await toAsyncWait(HealthApi.deleteRule({ id: row.id }));


### PR DESCRIPTION
## Summary

- translate delete confirmation messages before passing them to Element UI
- fix all five occurrences of the same raw Vue interpolation pattern
- stop enabling HTML rendering for these plain translated messages

## Validation

- `git diff --check`
- verified no `this.$confirm(...)` calls still contain the affected `{{ $t(...) }}` interpolation pattern
- frontend build was attempted with the repository's Yarn 1.22.22 configuration, but dependency installation could not complete because the runner disk was full (`ENOSPC`); no successful local build is claimed

Fixes #20

Signed-off-by: w3lld1 <42353747+w3lld1@users.noreply.github.com>
