### PR TITLE
fix: hide always-empty Thread Name columns in RPC call detail table

### DIFF
--- a/ai-apm-frontend/src/views/appMonitor/serviceCallDetail/table-list.vue
+++ b/ai-apm-frontend/src/views/appMonitor/serviceCallDetail/table-list.vue
@@ -167,6 +167,17 @@ export default class TableList extends Vue {
   ];
   get columns () {
     return this.columnsFullLabels.filter((item) => {
+      // 动态隐藏 RPC 调用详情中始终为空的「线程名」列：
+      // 当前列表所有行的 threadName 均为空时不展示该列
+      if (item.value === 'client.threadName' || item.value === 'server.threadName') {
+        const hasValue = this.tableList.some((row: any) => {
+          const v = row[item.value]
+          return v !== undefined && v !== null && v !== ''
+        })
+        if (!hasValue) {
+          return false
+        }
+      }
       if (Array.isArray(item.type)) {
         return item.type.includes(this.componentType)
       } else {


### PR DESCRIPTION
## Summary

On the RPC service call detail table (`/appMonitor/serviceCallDetail` for `componentType = service.rpc`), the "线程名 / Thread Name" columns under both the 发出端 (client) and 接收端 (server) groups always render `-`. SkyWalking Dubbo RPC spans carry no `thread.name` OTel attribute, so the backend never populates `threadName`, and the two columns permanently consume table width while showing no data.

This makes the `columns` getter reactively drop the `client.threadName` and `server.threadName` columns when no currently loaded row has a non-empty value for them. Because `columns` is a computed getter that reads `this.tableList`, it recomputes whenever the list is loaded, appended, or paginated. If a deployment's RPC spans do carry `thread.name`, the columns reappear automatically.

The change is frontend-only and scoped strictly to the two RPC threadName entries, using the flattened dotted keys (`row['client.threadName']`) the template already relies on. No backend change is needed.

## Why this matters

This resolves issue #8 (线程名列始终为空). It removes a permanently-empty column that wastes horizontal space in the RPC call detail view, while remaining self-correcting: the column shows if and only if real thread-name data is present. HTTP (`service.http`), DB (`service.db`), and MQ (`service.mq`) call detail tables are unaffected, as they never define threadName columns.

Verification: `yarn build` (tsc type-check + vite build) passes with no new errors.

Closes #8
