### PR TITLE
fix(skywalking): preserve trace HTTP status codes

### DIFF
--- a/ai-apm-demo/src/main/java/com/databuff/apm/demo/support/SkyWalkingTraceFixture.java
+++ b/ai-apm-demo/src/main/java/com/databuff/apm/demo/support/SkyWalkingTraceFixture.java
@@ -39,7 +39,7 @@ public final class SkyWalkingTraceFixture {
                 t0, t0 + 240, false,
                 tag("http.method", "GET"),
                 tag("url", "/demo/checkout"),
-                tag("status_code", "200"));
+                tag("http.status_code", "200"));
 
         SpanObject redisClient = exitSpanA(1, 0, "GET cart",
                 t0 + 5, t0 + 18, "redis:6379",
@@ -50,13 +50,13 @@ public final class SkyWalkingTraceFixture {
                 t0 + 12, t0 + 19, "payments.example.com:443",
                 tag("http.method", "GET"),
                 tag("url", "https://payments.example.com/api/risk/check"),
-                tag("status_code", "200"));
+                tag("http.status_code", "200"));
 
         SpanObject httpClient = exitSpanA(3, 0, "HTTP GET service-b /api/orders",
                 t0 + 20, t0 + 120, "service-b:8080",
                 tag("http.method", "GET"),
                 tag("url", "http://service-b:8080/api/orders/10001"),
-                tag("status_code", "200"));
+                tag("http.status_code", "200"));
 
         SpanObject esClient = exitSpanA(4, 0, "/orders/_search",
                 t0 + 100, t0 + 118, "es:9200",
@@ -101,7 +101,7 @@ public final class SkyWalkingTraceFixture {
                 t0 + 30, t0 + 110, false,
                 tag("http.method", "GET"),
                 tag("url", "/api/orders/10001"),
-                tag("status_code", "200"))
+                tag("http.status_code", "200"))
                 .toBuilder()
                 .addRefs(crossRef(traceId, segmentAId, 3, SERVICE_A, "service-a-1",
                         "GET /demo/checkout", "service-b:8080"))

--- a/ai-apm-ingest/src/main/java/com/databuff/apm/ingest/skywalking/SkyWalkingConverter.java
+++ b/ai-apm-ingest/src/main/java/com/databuff/apm/ingest/skywalking/SkyWalkingConverter.java
@@ -170,7 +170,11 @@ public final class SkyWalkingConverter {
             return;
         }
         dc.metaHttpMethod = firstNonBlank(meta.get("http.method"), meta.get("http.request.method"));
-        dc.metaHttpStatusCode = parseInt(firstNonBlank(meta.get("http.status_code"), meta.get("status_code")));
+        Integer httpStatusCode = parseInt(firstNonBlank(meta.get("http.status_code"), meta.get("status_code")));
+        dc.metaHttpStatusCode = httpStatusCode;
+        if (httpStatusCode != null) {
+            meta.put("http.status_code", String.valueOf(httpStatusCode));
+        }
         String url = firstNonBlank(meta.get("url"), meta.get("http.url"), meta.get("http.route"));
         if (url != null && !DcSpanUtil.isRpcProtocolUrl(url)) {
             dc.metaHttpUrl = DcSpanUtil.normalizeHttpUrl(url);

--- a/ai-apm-ingest/src/test/java/com/databuff/apm/ingest/skywalking/SkyWalkingConverterTest.java
+++ b/ai-apm-ingest/src/test/java/com/databuff/apm/ingest/skywalking/SkyWalkingConverterTest.java
@@ -3,6 +3,7 @@ package com.databuff.apm.ingest.skywalking;
 import com.databuff.apm.common.meta.OtelAttributeMaps;
 import com.databuff.apm.common.meta.SpanDirectionUtil;
 import com.databuff.apm.common.model.DcSpan;
+import com.databuff.apm.common.serde.DCSpanJsonEncoder;
 import com.databuff.apm.common.serde.DcSpanUtil;
 import com.databuff.apm.ingest.otel.OtlLogLine;
 import com.databuff.apm.ingest.otel.OtlMetricLine;
@@ -28,6 +29,7 @@ import org.apache.skywalking.apm.network.logging.v3.TextLog;
 import org.apache.skywalking.apm.network.logging.v3.TraceContext;
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 
@@ -55,7 +57,7 @@ class SkyWalkingConverterTest {
                         .setSpanType(SpanType.Entry)
                         .addTags(tag("http.method", "GET"))
                         .addTags(tag("url", "http://example/orders"))
-                        .addTags(tag("status_code", "200")))
+                        .addTags(tag("http.status_code", "200")))
                 .build();
 
         DcSpan span = converter.convertSegment(segment).get(0).span();
@@ -65,8 +67,37 @@ class SkyWalkingConverterTest {
         assertThat(span.metaHttpMethod).isEqualTo("GET");
         assertThat(span.metaHttpUrl).isEqualTo("/orders");
         assertThat(span.metaHttpStatusCode).isEqualTo(200);
+        assertThat(OtelAttributeMaps.meta(span)).containsEntry("http.status_code", "200");
         assertThat(TraceDataSources.resolve(OtelAttributeMaps.parse(span))).isEqualTo(TraceDataSources.SKY_WALKING);
         assertThat(SpanDirectionUtil.resolve(span).isIn()).isEqualTo(1);
+    }
+
+    @Test
+    void canonicalizesLegacyHttpStatusCodeTag() throws Exception {
+        SegmentObject segment = SegmentObject.newBuilder()
+                .setTraceId("trace-legacy-status")
+                .setTraceSegmentId("segment-legacy-status")
+                .setService("legacy-http-service")
+                .addSpans(SpanObject.newBuilder()
+                        .setSpanId(0)
+                        .setParentSpanId(-1)
+                        .setStartTime(1_700_000_000_000L)
+                        .setEndTime(1_700_000_000_010L)
+                        .setOperationName("GET /legacy")
+                        .setSpanType(SpanType.Entry)
+                        .setSpanLayer(SpanLayer.Http)
+                        .addTags(tag("http.method", "GET"))
+                        .addTags(tag("status_code", "204")))
+                .build();
+
+        DcSpan span = converter.convertSegment(segment).get(0).span();
+
+        assertThat(span.metaHttpStatusCode).isEqualTo(204);
+        assertThat(OtelAttributeMaps.meta(span))
+                .containsEntry("status_code", "204")
+                .containsEntry("http.status_code", "204");
+        assertThat(new String(DCSpanJsonEncoder.encode(span), StandardCharsets.UTF_8))
+                .contains("\"meta.http.status_code\":204");
     }
 
     @Test
@@ -85,7 +116,7 @@ class SkyWalkingConverterTest {
                         .setPeer("payments.example.com:443")
                         .addTags(tag("http.method", "GET"))
                         .addTags(tag("url", "https://payments.example.com/api/risk/check"))
-                        .addTags(tag("status_code", "200")))
+                        .addTags(tag("http.status_code", "200")))
                 .build();
 
         DcSpan span = converter.convertSegment(segment).get(0).span();
@@ -93,6 +124,48 @@ class SkyWalkingConverterTest {
         Map<String, String> meta = OtelAttributeMaps.parse(span);
         assertThat(meta.get("server.address")).isEqualTo("payments.example.com");
         assertThat(meta.get("server.port")).isEqualTo("443");
+    }
+
+    @Test
+    void doesNotInventHttpStatusCodeWhenTagIsMissingOrInvalid() {
+        SegmentObject missingStatus = SegmentObject.newBuilder()
+                .setTraceId("trace-missing-status")
+                .setTraceSegmentId("segment-missing-status")
+                .setService("missing-status-service")
+                .addSpans(SpanObject.newBuilder()
+                        .setSpanId(0)
+                        .setParentSpanId(-1)
+                        .setStartTime(1_700_000_000_000L)
+                        .setEndTime(1_700_000_000_010L)
+                        .setOperationName("GET /missing")
+                        .setSpanType(SpanType.Entry)
+                        .setSpanLayer(SpanLayer.Http))
+                .build();
+        SegmentObject invalidStatus = SegmentObject.newBuilder()
+                .setTraceId("trace-invalid-status")
+                .setTraceSegmentId("segment-invalid-status")
+                .setService("invalid-status-service")
+                .addSpans(SpanObject.newBuilder()
+                        .setSpanId(0)
+                        .setParentSpanId(-1)
+                        .setStartTime(1_700_000_000_000L)
+                        .setEndTime(1_700_000_000_010L)
+                        .setOperationName("GET /invalid")
+                        .setSpanType(SpanType.Entry)
+                        .setSpanLayer(SpanLayer.Http)
+                        .addTags(tag("status_code", "not-a-number")))
+                .build();
+
+        DcSpan missingSpan = converter.convertSegment(missingStatus).get(0).span();
+        DcSpan invalidSpan = converter.convertSegment(invalidStatus).get(0).span();
+
+        assertThat(missingSpan.metaHttpStatusCode).isNull();
+        assertThat(OtelAttributeMaps.meta(missingSpan))
+                .doesNotContainKeys("status_code", "http.status_code");
+        assertThat(invalidSpan.metaHttpStatusCode).isNull();
+        assertThat(OtelAttributeMaps.meta(invalidSpan))
+                .containsEntry("status_code", "not-a-number")
+                .doesNotContainKey("http.status_code");
     }
 
     @Test

--- a/ai-apm-web/src/test/java/com/databuff/apm/web/portal/TracePortalServiceTest.java
+++ b/ai-apm-web/src/test/java/com/databuff/apm/web/portal/TracePortalServiceTest.java
@@ -111,6 +111,10 @@ class TracePortalServiceTest {
         assertThat(list).hasSize(1);
         assertThat(list.get(0).get("trace_id")).isEqualTo("t1");
         assertThat(list.get(0).get("serviceId")).isEqualTo("464a0a08964a061e");
+        assertThat(list.get(0).get("metaHttpStatusCode")).isEqualTo(500);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> meta = (Map<String, Object>) list.get(0).get("meta");
+        assertThat(meta.get("http.status_code")).isEqualTo(500);
     }
 
     @Test


### PR DESCRIPTION
## Summary

- normalize both `http.status_code` and legacy `status_code` at the SkyWalking ingest boundary while preserving `http.status_code` as the canonical metadata key
- keep missing or invalid status values unset, so non-HTTP/RPC spans are not reported as HTTP 200
- update the native SkyWalking demo fixture and pin both the Doris serialization and `/webapi/trace/list` response contracts with regression tests

## Root cause

The converter populated the typed status column from the legacy `status_code` tag, but did not retain the canonical `meta["http.status_code"]` key. The repository-owned SkyWalking fixture also emitted only the legacy tag, so the current protocol key and the full storage/API/UI contract were not covered end to end.

## Validation

- `SkyWalkingConverterTest`: 10 tests, 0 failures
- adjacent trace/metric tests: 43 tests, 0 failures
- `TracePortalServiceTest`: 30 tests, 0 failures
- backend reactor: 1,398 tests, 0 failures, 0 errors, 22 skipped after excluding two pre-existing Windows-sensitive test classes (`OtlLogLineTest`, `AgentRuntimeConfigTest`); the unfiltered baseline reproduces 3 assertions caused by console encoding/path separators
- `yarn --cwd ai-apm-frontend build`
- local Docker SkyWalking path: Doris stores typed and canonical `200` values for HTTP spans; Dubbo/RPC spans remain null
- release gate C: trace group 8/8; full protocol-specific run 94/106, with 12 unrelated SkyWalking-vs-OTLP fixture mismatches
- browser QA: trace list and HTTP span detail render `200`; Dubbo span has no response code; 0 console errors; trace API requests return 200

## Follow-up verification

The post-deploy check against `192.168.50.140:27403` could not be run because the target timed out from this environment. After deployment, repeat the issue flow with newly ingested traces to confirm Doris, API, and UI values on that environment.

Fixes #33