### PR TITLE
docs: add Python OTLP integration quick-start guide #27

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -31,6 +31,7 @@ curl -fsSL https://databuff.ai/databuff/ai-apm-install.sh | bash
 
 - [OpenTelemetry OTLP 接入](opentelemetry-otlp-ingestion.md)
 - [Spring Boot OTLP 接入](快速入门/spring-boot-otlp-integration.md)
+- [Python OTLP 接入](快速入门/python-otlp-integration.md)
 - [Docker 安装部署](快速入门/docker安装部署.md)
 - [K8s 安装部署](快速入门/k8s安装部署.md)
 

--- a/docs/README_en.md
+++ b/docs/README_en.md
@@ -31,6 +31,7 @@ Online docs: [databuff.ai/docs](https://databuff.ai/docs/en/)
 
 - [OpenTelemetry OTLP Ingestion](opentelemetry-otlp-ingestion_en.md)
 - [Spring Boot OTLP Integration](快速入门/spring-boot-otlp-integration_en.md)
+- [Python OTLP Integration](快速入门/python-otlp-integration_en.md)
 - [Docker Installation](快速入门/docker安装部署_en.md)
 - [Kubernetes Installation](快速入门/k8s安装部署_en.md)
 

--- a/docs/快速入门/python-otlp-integration.md
+++ b/docs/快速入门/python-otlp-integration.md
@@ -1,68 +1,193 @@
-Python OTLP 集成快速入门指南
+<p align="center">
+  <a href="python-otlp-integration.md">中文</a>
+  &nbsp;|&nbsp;
+  <a href="python-otlp-integration_en.md">English</a>
+</p>
 
-本指南将逐步介绍如何通过 OpenTelemetry (OTLP) 将 Python 应用程序连接到 DataBuff，以实现应用链路追踪 (Traces) 和指标 (Metrics) 的数据采集。
-前置条件
+# Python OTLP 接入
 
-在配置 Python 应用程序之前，请确保 DataBuff Platform 的核心组件已在您的基础设施中正常运行。
+用 **OpenTelemetry Python** 给 Flask 应用做埋点，把 Trace 和 Metrics 经 **OTLP** 上报到 DataBuff。
 
-请参考 Docker 安装部署指南 完成 DataBuff 后端服务的启动与配置。
+适合已有 Python Web 项目、希望用环境变量完成接入的场景。通用 OTLP 说明见
+[OpenTelemetry OTLP 接入](../opentelemetry-otlp-ingestion.md)。
 
-步骤 1：安装 OpenTelemetry SDK 与依赖项
+## 前置条件
 
-使用 pip 安装所需的 OpenTelemetry SDK 核心库、OTLP 导出器协议包以及用于构建示例应用的 Flask 框架：
+- Python 3.9+
+- 已部署 DataBuff，且应用进程能访问 Ingest 的 OTLP 端口
 
-pip install flask
+## 1. 启动 DataBuff
 
-opentelemetry-api
+按 [Docker 安装部署](docker安装部署.md) 一键安装平台。安装完成后终端会输出接入地址，默认如下：
 
-opentelemetry-sdk
+| 用途 | 地址 |
+|------|------|
+| Web UI | `http://<本机IP>:27403` |
+| 默认账号 | `admin` / `Databuff@123` |
+| OTLP gRPC | `<本机IP>:4317` |
+| OTLP HTTP | `http://<本机IP>:4318` |
 
-opentelemetry-exporter-otlp
+下文将 `<ingest-host>` 替换为 Ingest 所在主机名或 IP（本机 Docker 安装时通常为 `localhost` 或 `127.0.0.1`）。
 
-opentelemetry-instrumentation-flask
-步骤 2：构建基础 Python 应用程序
+## 2. 安装 OpenTelemetry Python SDK
 
-在您的工作目录中创建一个名为 app.py 的文件，并添加以下 Python 代码。该脚本将初始化 OpenTelemetry 追踪提供者 (Tracer Provider)，将数据路由至本地 DataBuff 接收端，并自动对 Flask Web 服务器进行埋点监控：
+```bash
+pip install flask \
+  opentelemetry-distro \
+  opentelemetry-exporter-otlp
+opentelemetry-bootstrap -a install
+```
 
+`opentelemetry-distro` 提供 `opentelemetry-instrument` 启动器；
+`opentelemetry-bootstrap -a install` 会按当前环境安装 Flask 等自动埋点包。
+
+## 3. 最小 Flask 应用
+
+在工作目录创建 `app.py`：
+
+```python
 from flask import Flask
-from opentelemetry import trace
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import BatchSpanProcessor
-from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
-from opentelemetry.instrumentation.flask import FlaskInstrumentor
-1. 初始化 Tracer Provider
 
-provider = TracerProvider()
-trace.set_tracer_provider(provider)
-2. 配置 OTLP Exporter 指向 DataBuff gRPC 数据接收端口
-DataBuff 默认的 OTLP gRPC 端口为 http://localhost:4317
+app = Flask(__name__)
 
-otlp_exporter = OTLPSpanExporter(endpoint="http://localhost:4317", insecure=True)
-provider.add_span_processor(BatchSpanProcessor(otlp_exporter))
-3. 创建并对 Flask 应用实例进行自动埋点 (Instrumentation)
-
-app = Flask(name)
-FlaskInstrumentor().instrument_app(app)
 
 @app.route("/")
 def index():
-return "DataBuff Python OTLP Integration active."
+    return "ok\n"
 
-if name == "main":
-app.run(port=5000)
-步骤 3：运行应用并生成测试流量
 
-在终端环境中运行配置好的 Python 应用程序：
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5000)
+```
 
-python app.py
+业务代码无需引入 OpenTelemetry。埋点由启动器完成，和 Spring Boot 的 Java Agent 类似。
 
-打开另一个终端窗口或使用浏览器，发送多次模拟 HTTP 请求以触发链路数据采集：
+## 4. 配置 OTLP 导出
 
+启动前设置环境变量，将 `<ingest-host>` 换成实际地址：
+
+```bash
+export OTEL_SERVICE_NAME=my-python-service
+export OTEL_TRACES_EXPORTER=otlp
+export OTEL_METRICS_EXPORTER=otlp
+export OTEL_EXPORTER_OTLP_ENDPOINT="http://<ingest-host>:4318"
+export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+```
+
+使用 gRPC 时：
+
+```bash
+export OTEL_EXPORTER_OTLP_ENDPOINT="http://<ingest-host>:4317"
+export OTEL_EXPORTER_OTLP_PROTOCOL=grpc
+```
+
+> **提示**：Docker 与本机 Python 同机运行时，`<ingest-host>` 用 `localhost`；
+> 应用在容器内、DataBuff 在宿主机时，用宿主机 IP 或 `host.docker.internal`
+> （macOS / Windows Docker Desktop）。
+
+## 5. 启动应用并产生流量
+
+```bash
+opentelemetry-instrument python app.py
+```
+
+另开一个终端发送几次请求：
+
+```bash
 curl http://localhost:5000/
-步骤 4：在 DataBuff UI 中验证数据
+```
 
-打开浏览器并登录本地的 DataBuff UI 控制台。
+FastAPI 同样可用启动器：安装 `fastapi uvicorn` 后执行 `opentelemetry-bootstrap -a install`，
+再用 `opentelemetry-instrument uvicorn main:app --port 5000`。
 
-直接导航至 Trace Center (链路中心) 或 Metrics List View (指标列表视图)。
+### 可选：在代码里初始化 SDK
 
-验证来自 Python 应用的事务流数据是否已被成功索引、渲染并在活跃的可视化网格中正确映射。
+不使用启动器时，可在进程入口配置 Tracer / Meter，并手动对 Flask 埋点：
+
+```python
+from flask import Flask
+from opentelemetry import metrics, trace
+from opentelemetry.exporter.otlp.proto.http.metric_exporter import (
+    OTLPMetricExporter,
+)
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
+    OTLPSpanExporter,
+)
+from opentelemetry.instrumentation.flask import FlaskInstrumentor
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+resource = Resource.create({"service.name": "my-python-service"})
+endpoint = "http://<ingest-host>:4318"
+
+tracer_provider = TracerProvider(resource=resource)
+tracer_provider.add_span_processor(
+    BatchSpanProcessor(OTLPSpanExporter(endpoint=f"{endpoint}/v1/traces"))
+)
+trace.set_tracer_provider(tracer_provider)
+
+metrics.set_meter_provider(
+    MeterProvider(
+        resource=resource,
+        metric_readers=[
+            PeriodicExportingMetricReader(
+                OTLPMetricExporter(endpoint=f"{endpoint}/v1/metrics")
+            )
+        ],
+    )
+)
+
+app = Flask(__name__)
+FlaskInstrumentor().instrument_app(app)
+
+
+@app.route("/")
+def index():
+    return "ok\n"
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5000)
+```
+
+对应依赖：
+
+```bash
+pip install flask \
+  opentelemetry-sdk \
+  opentelemetry-exporter-otlp \
+  opentelemetry-instrumentation-flask
+```
+
+然后直接 `python app.py`（不要再包一层 `opentelemetry-instrument`）。
+
+## 6. 在 DataBuff 中验证
+
+1. 打开 Web UI：`http://<ingest-host>:27403`，使用默认账号登录
+2. 进入 **应用性能 → 服务列表**，确认出现 `my-python-service`（或你配置的 `OTEL_SERVICE_NAME`）
+3. 进入 **应用性能 → 链路追踪**，查看刚才请求产生的 Trace
+4. 在服务详情中查看 HTTP 等指标曲线
+
+若无数据，请检查：Ingest 端口是否可达、服务名是否与列表一致、应用日志中是否有 OTLP 导出错误。
+更多接入细节见 [OpenTelemetry OTLP 接入](../opentelemetry-otlp-ingestion.md)。
+
+## 可选：采样与导出频率
+
+生产环境可通过环境变量控制采样与指标导出间隔
+（详见 [性能优化](../运维参考/性能优化.md#如何配置-otel-采样-应用侧)）：
+
+```bash
+export OTEL_TRACES_SAMPLER=parentbased_traceidratio
+export OTEL_TRACES_SAMPLER_ARG=0.1          # 约 10% Trace
+export OTEL_METRIC_EXPORT_INTERVAL=60000    # 指标 60s 导出一次
+```
+
+## 相关文档
+
+- [Docker 安装部署](docker安装部署.md)
+- [OpenTelemetry OTLP 接入](../opentelemetry-otlp-ingestion.md)
+- [Spring Boot OTLP 接入](spring-boot-otlp-integration.md)
+- [应用性能](../使用手册/应用性能.md)

--- a/docs/快速入门/python-otlp-integration_en.md
+++ b/docs/快速入门/python-otlp-integration_en.md
@@ -1,68 +1,204 @@
-Python OTLP Integration Quick-Start Guide
+<p align="center">
+  <a href="python-otlp-integration.md">中文</a>
+  &nbsp;|&nbsp;
+  <a href="python-otlp-integration_en.md">English</a>
+</p>
 
-This guide provides a step-by-step walkthrough for connecting a Python application to DataBuff via OpenTelemetry (OTLP) to ingest application traces and metrics.
-Prerequisites
+# Python OTLP Integration
 
-Before configuring your Python application, ensure that the core DataBuff platform components are up and running on your infrastructure.
+Instrument a Flask app with **OpenTelemetry Python** and export traces and
+metrics to DataBuff over **OTLP**.
 
-Please refer to the Docker Deployment Guide to set up and start the DataBuff backend services.
+Best for existing Python web apps that can be wired up with environment
+variables. For general OTLP details, see
+[OpenTelemetry OTLP Ingestion](../opentelemetry-otlp-ingestion_en.md).
 
-Step 1: Install OpenTelemetry SDK & Dependencies
+## Prerequisites
 
-Install the required OpenTelemetry SDK core libraries, the OTLP exporter protocol packages, and Flask (which we will use to build a minimal target application) using pip:
+- Python 3.9+
+- DataBuff deployed and reachable from the app process on the OTLP ports
 
-pip install flask
+## 1. Start DataBuff
 
-opentelemetry-api
+Follow [Docker Installation](docker安装部署_en.md). After install, the terminal
+prints endpoints. Defaults:
 
-opentelemetry-sdk
+| Purpose | Address |
+|---------|---------|
+| Web UI | `http://<host-ip>:27403` |
+| Default login | `admin` / `Databuff@123` |
+| OTLP gRPC | `<host-ip>:4317` |
+| OTLP HTTP | `http://<host-ip>:4318` |
 
-opentelemetry-exporter-otlp
+Replace `<ingest-host>` below with the Ingest hostname or IP (usually
+`localhost` or `127.0.0.1` for local Docker).
 
-opentelemetry-instrumentation-flask
-Step 2: Instrument a Minimal Python Application
+## 2. Install the OpenTelemetry Python SDK
 
-Create a new file named app.py in your working directory and add the following Python snippet. This script initializes the OpenTelemetry tracer provider, routes data to the local DataBuff ingest endpoint, and auto-instruments a standard Flask web server:
+```bash
+pip install flask \
+  opentelemetry-distro \
+  opentelemetry-exporter-otlp
+opentelemetry-bootstrap -a install
+```
 
+`opentelemetry-distro` provides the `opentelemetry-instrument` launcher.
+`opentelemetry-bootstrap -a install` installs auto-instrumentation packages
+for libraries in the current environment, including Flask.
+
+## 3. Minimal Flask app
+
+Create `app.py` in your working directory:
+
+```python
 from flask import Flask
-from opentelemetry import trace
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import BatchSpanProcessor
-from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
-from opentelemetry.instrumentation.flask import FlaskInstrumentor
-1. Initialize the Tracer Provider
 
-provider = TracerProvider()
-trace.set_tracer_provider(provider)
-2. Configure the OTLP Exporter to target the DataBuff gRPC ingestion port
-Default DataBuff OTLP gRPC endpoint is http://localhost:4317
+app = Flask(__name__)
 
-otlp_exporter = OTLPSpanExporter(endpoint="http://localhost:4317", insecure=True)
-provider.add_span_processor(BatchSpanProcessor(otlp_exporter))
-3. Create and instrument the Flask application instance
-
-app = Flask(name)
-FlaskInstrumentor().instrument_app(app)
 
 @app.route("/")
 def index():
-return "DataBuff Python OTLP Integration active."
+    return "ok\n"
 
-if name == "main":
-app.run(port=5000)
-Step 3: Execute and Generate Traffic
 
-Run the instrumented Python application inside your terminal environment:
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5000)
+```
 
-python app.py
+The app itself does not import OpenTelemetry. The launcher injects
+instrumentation, similar to the Java Agent used in the Spring Boot guide.
 
-Open a separate terminal prompt or use a web browser to send multiple mock HTTP requests to trigger trace collection:
+## 4. Configure OTLP export
 
+Set these before starting the app; replace `<ingest-host>` with your Ingest
+address:
+
+```bash
+export OTEL_SERVICE_NAME=my-python-service
+export OTEL_TRACES_EXPORTER=otlp
+export OTEL_METRICS_EXPORTER=otlp
+export OTEL_EXPORTER_OTLP_ENDPOINT="http://<ingest-host>:4318"
+export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+```
+
+For gRPC:
+
+```bash
+export OTEL_EXPORTER_OTLP_ENDPOINT="http://<ingest-host>:4317"
+export OTEL_EXPORTER_OTLP_PROTOCOL=grpc
+```
+
+> **Note**: Use `localhost` when Docker and the Python app run on the same
+> machine. If the app is in a container and DataBuff is on the host, use the
+> host IP or `host.docker.internal` (macOS / Windows Docker Desktop).
+
+## 5. Run the app and generate traffic
+
+```bash
+opentelemetry-instrument python app.py
+```
+
+In another terminal, send a few requests:
+
+```bash
 curl http://localhost:5000/
-Step 4: Verify Traces and Metrics in DataBuff UI
+```
 
-Launch your browser environment and log into the local DataBuff UI dashboard.
+FastAPI works the same way: install `fastapi uvicorn`, run
+`opentelemetry-bootstrap -a install`, then
+`opentelemetry-instrument uvicorn main:app --port 5000`.
 
-Navigate directly to the Trace Center or Metrics List View.
+### Optional: initialize the SDK in code
 
-Verify that the incoming transaction streams labeled from your application framework are indexed, rendered, and mapping correctly within the active visualization grids.
+Without the launcher, configure the tracer and meter at process start and
+instrument Flask yourself:
+
+```python
+from flask import Flask
+from opentelemetry import metrics, trace
+from opentelemetry.exporter.otlp.proto.http.metric_exporter import (
+    OTLPMetricExporter,
+)
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
+    OTLPSpanExporter,
+)
+from opentelemetry.instrumentation.flask import FlaskInstrumentor
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+resource = Resource.create({"service.name": "my-python-service"})
+endpoint = "http://<ingest-host>:4318"
+
+tracer_provider = TracerProvider(resource=resource)
+tracer_provider.add_span_processor(
+    BatchSpanProcessor(OTLPSpanExporter(endpoint=f"{endpoint}/v1/traces"))
+)
+trace.set_tracer_provider(tracer_provider)
+
+metrics.set_meter_provider(
+    MeterProvider(
+        resource=resource,
+        metric_readers=[
+            PeriodicExportingMetricReader(
+                OTLPMetricExporter(endpoint=f"{endpoint}/v1/metrics")
+            )
+        ],
+    )
+)
+
+app = Flask(__name__)
+FlaskInstrumentor().instrument_app(app)
+
+
+@app.route("/")
+def index():
+    return "ok\n"
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5000)
+```
+
+Dependencies:
+
+```bash
+pip install flask \
+  opentelemetry-sdk \
+  opentelemetry-exporter-otlp \
+  opentelemetry-instrumentation-flask
+```
+
+Then run `python app.py` directly (do not wrap it with
+`opentelemetry-instrument`).
+
+## 6. Verify in DataBuff
+
+1. Open the Web UI: `http://<ingest-host>:27403` and sign in with the default account
+2. Go to **Application Performance → Services** and confirm `my-python-service` (or your `OTEL_SERVICE_NAME`) appears
+3. Go to **Application Performance → Traces** and open a trace from the requests you just sent
+4. Check HTTP metric charts on the service detail page
+
+If nothing shows up, confirm the Ingest ports are reachable, the service name
+matches the list, and the app log has no OTLP export errors. More detail:
+[OpenTelemetry OTLP Ingestion](../opentelemetry-otlp-ingestion_en.md).
+
+## Optional: sampling and export interval
+
+In production, control sampling and metric export interval with environment
+variables (see [Performance Tuning](../运维参考/性能优化_en.md)):
+
+```bash
+export OTEL_TRACES_SAMPLER=parentbased_traceidratio
+export OTEL_TRACES_SAMPLER_ARG=0.1          # ~10% of traces
+export OTEL_METRIC_EXPORT_INTERVAL=60000    # export metrics every 60s
+```
+
+## Related docs
+
+- [Docker Installation](docker安装部署_en.md)
+- [OpenTelemetry OTLP Ingestion](../opentelemetry-otlp-ingestion_en.md)
+- [Spring Boot OTLP Integration](spring-boot-otlp-integration_en.md)
+- [Application Performance](../使用手册/应用性能_en.md)


### PR DESCRIPTION
Fixes #27

Rewrote the Python OTLP quick start to match the Spring Boot guide.
The previous pages had no markdown and the Flask sample does not run.
Also linked them from the docs index.
