### PR TITLE
docs: add alert rule configuration example #11

### DIFF
--- a/docs/使用手册/告警.md
+++ b/docs/使用手册/告警.md
@@ -69,6 +69,52 @@ flowchart LR
 - 处理日志
 
 指标恢复后告警自动标记为已解决。
+---
+
+## 配置示例
+
+以「order-service 错误率连续 5 分钟高于 5%」为例。在 **配置管理 → 告警配置 → 新建规则** 按下表填写：
+
+| 字段 | 取值 | 说明 |
+|------|------|------|
+| 规则名称 | `order-service 错误率过高` | 告警列表里用来辨认这条规则 |
+| 监控对象 | `order-service` | 只评估该服务；也可改成实例 |
+| 指标 | 错误率（`error_rate` / `service.error.pct`） | 用百分比，不是 0–1 小数 |
+| 条件 | 阈值，大于（`gt`） | 也可用小于，或改成突变检测 |
+| 阈值 | `5` | 即 5% |
+| 回看窗口 | `300` 秒 | 每次评估看最近 5 分钟；平台默认每分钟跑一次 |
+| 级别 | 严重（`critical`） | 也可选提示 / 警告 |
+| 启用 | 是 | 关掉后不再评估 |
+
+等价 YAML：
+
+```yaml
+ruleName: order-service 错误率过高
+enabled: true
+service: order-service
+metric: error_rate
+detectionWay: threshold
+comparator: gt
+threshold: 5
+period: 300          # seconds, last 5 minutes
+level: critical
+```
+
+对应规则查询 JSON（`queryJson` 里的评估块）：
+
+```json
+{
+  "1": {
+    "way": "threshold",
+    "period": 300,
+    "view_unit": "%",
+    "thresholds": { "critical": 5 },
+    "A": { "metric": "service.error.pct", "from": [] }
+  }
+}
+```
+
+保存并启用后，评估任务按分钟检查最近 5 分钟错误率。一旦高于 5%，**告警中心 → 告警列表** 会出现一行，描述类似「错误率的 12% 值超过阈值 5%」，状态为待处理，并可点进详情看指标趋势、关联 Trace / 日志。指标回落后该行自动标为已解决；同一告警下的触发记录可在详情的事件列表里查看。
 
 ---
 

--- a/docs/使用手册/告警_en.md
+++ b/docs/使用手册/告警_en.md
@@ -67,6 +67,58 @@ Filter by service, severity, status. Click an alert for details:
 - Handling log
 
 Alerts auto-resolve when metrics recover.
+---
+
+## Configuration Example
+
+Example: fire when `order-service` error rate stays above 5% for 5 minutes.
+Create it under **Configuration → Alert Config → New Rule**:
+
+| Field | Value | Meaning |
+|-------|-------|---------|
+| Rule name | `order-service error rate too high` | How the row is labeled in the alert list |
+| Scope | `order-service` | Service (or an instance) to evaluate |
+| Metric | Error rate (`error_rate` / `service.error.pct`) | Percent, not a 0–1 fraction |
+| Condition | Threshold, greater than (`gt`) | Or less-than / change detection |
+| Threshold | `5` | 5% |
+| Lookback | `300` seconds | Each run uses the last 5 minutes; the job itself runs every minute |
+| Severity | Critical (`critical`) | Info / Warning also exist |
+| Enabled | yes | Disabled rules are not evaluated |
+
+Equivalent YAML:
+
+```yaml
+ruleName: order-service error rate too high
+enabled: true
+service: order-service
+metric: error_rate
+detectionWay: threshold
+comparator: gt
+threshold: 5
+period: 300          # seconds, last 5 minutes
+level: critical
+```
+
+Matching evaluation JSON (the block stored in `queryJson`):
+
+```json
+{
+  "1": {
+    "way": "threshold",
+    "period": 300,
+    "view_unit": "%",
+    "thresholds": { "critical": 5 },
+    "A": { "metric": "service.error.pct", "from": [] }
+  }
+}
+```
+
+After you save and enable it, evaluation checks the last 5 minutes every minute.
+When the rate is above 5%, a row shows up under **Alert Center → Alert List**,
+with a description like "error rate 12% exceeded threshold 5%", status open.
+Open it for metric trend, related traces and logs. When the metric recovers the
+row is marked resolved. Trigger records for that alert sit in the event list on
+the detail page.
 
 ---
 


### PR DESCRIPTION
Fixes #11

Added a configuration example to the alerts manual (Chinese and English) for a threshold rule: order-service error rate above 5% for 5 minutes, plus how that row shows up in the alert / event list.